### PR TITLE
Use os.execvp() rather than os.system()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+*.egg-info

--- a/goldenarch/core.py
+++ b/goldenarch/core.py
@@ -13,17 +13,17 @@ import sys
 import static
 
 PORT = os.environ.get('PORT', 8000)
-STATIC_DIR = sys.argv[1]
 
-
-app = static.Cling(STATIC_DIR)
-
+def app(static_dir):
+    return static.Cling(static_dir)
 
 def cli():
     print 'Serving crap. Fast.'
 
+    static_dir = sys.argv[1]
+
     argv = [
-        'gunicorn', 'goldenarch:app',
+        'gunicorn', 'goldenarch:app("{dir}")'.format(dir=static_dir),
         '-b', '0.0.0.0:{port}'.format(port=PORT),
         '-w', '16', '-k', 'gevent', '-t', '2',
         '--name', 'goldenarch'


### PR DESCRIPTION
This change causes goldenarch to use the `execvp` syscall to start gunicorn rather than `os.system()`. At the moment, even if you can successfully kill the main goldenarch process, gunicorn (and its worker processes) often keep running, requiring a `pkill python` or similar. This resolves this issue by replacing the main process with the gunicorn process, delegating all signal handling to gunicorn. 
